### PR TITLE
Document a better installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ spoofed as well and we want to present a final solution anyone can deploy.
 
 ## Installing Whip.
 
-Simply add Whip to your composer.json `require` field like so:
+Simply run the following [composer](https://getcomposer.org/) command:
 
-    "require": {
-        "vectorface/whip": "~0.1.0"
-    }
+```shell
+$ composer require vectorface/whip
+```
 
 ## Using Whip
 


### PR DESCRIPTION
Same thing that was done here with [DUnit](https://github.com/Vectorface/dunit/pull/7).
This command will get the most stable version and pre-append a tilde.

Example:

``` shell
$ composer require vectorface/whip
Using version ~0.2 for vectorface/whip
```
