### PR TITLE
Fix fallback to remote addr

### DIFF
--- a/src/Whip.php
+++ b/src/Whip.php
@@ -151,15 +151,21 @@ class Whip
         $source = $this->getRequestAdapter($this->coalesceSources($source));
         $remoteAddr = $source->getRemoteAddr();
         $requestHeaders = $source->getHeaders();
+        $ipAddress = false;
 
         foreach (self::$headers as $key => $headers) {
             if (!$this->isMethodUsable($key, $remoteAddr)) {
                 continue;
             }
-            return $this->extractAddressFromHeaders($requestHeaders, $headers);
+
+            $ipAddress = $this->extractAddressFromHeaders($requestHeaders, $headers);
         }
 
-        return ($this->enabled & self::REMOTE_ADDR) ? $remoteAddr : false;
+        if (!$ipAddress && $remoteAddr && ($this->enabled & self::REMOTE_ADDR)) {
+            $ipAddress = $remoteAddr;
+        }
+
+        return $ipAddress;
     }
 
     /**

--- a/src/Whip.php
+++ b/src/Whip.php
@@ -151,21 +151,22 @@ class Whip
         $source = $this->getRequestAdapter($this->coalesceSources($source));
         $remoteAddr = $source->getRemoteAddr();
         $requestHeaders = $source->getHeaders();
-        $ipAddress = false;
 
         foreach (self::$headers as $key => $headers) {
             if (!$this->isMethodUsable($key, $remoteAddr)) {
                 continue;
             }
 
-            $ipAddress = $this->extractAddressFromHeaders($requestHeaders, $headers);
+            if ($ipAddress = $this->extractAddressFromHeaders($requestHeaders, $headers)) {
+                return $ipAddress;
+            }
         }
 
-        if (!$ipAddress && $remoteAddr && ($this->enabled & self::REMOTE_ADDR)) {
-            $ipAddress = $remoteAddr;
+        if ($remoteAddr && ($this->enabled & self::REMOTE_ADDR)) {
+            return $remoteAddr;
         }
 
-        return $ipAddress;
+        return false;
     }
 
     /**

--- a/tests/WhipTest.php
+++ b/tests/WhipTest.php
@@ -444,4 +444,16 @@ class WhipTest extends PHPUnit_Framework_TestCase
         $lookup->setSource($source);
         $this->assertEquals($source['REMOTE_ADDR'], $lookup->getIpAddress());
     }
+
+    /**
+     * Tests that we fallback to REMOTE_ADDR if the custom header was not found
+     */
+    public function testFallbackToRemoteAddr()
+    {
+        $source = array(
+            'REMOTE_ADDR' => '24.24.24.24'
+        );
+        $lookup = new Whip(Whip::PROXY_HEADERS | Whip::REMOTE_ADDR, array(), $source);
+        $this->assertEquals($source['REMOTE_ADDR'], $lookup->getIpAddress());
+    }
 }


### PR DESCRIPTION
As mentioned in docs if you pass the bitmask `Whip::CLOUDFLARE_HEADERS | Whip::REMOTE_ADDR` should work fallback to `$_SERVER['REMOTE_ADDR']`, but it`s not