### PR TITLE
Fixed package title header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-#Whip
+# Whip
+
 [![Build Status](https://travis-ci.org/Vectorface/whip.svg?branch=master)](https://travis-ci.org/Vectorface/whip)
 [![Code Coverage](https://scrutinizer-ci.com/g/Vectorface/whip/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/Vectorface/whip/?branch=master)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Vectorface/whip/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Vectorface/whip/?branch=master)


### PR DESCRIPTION
Github changed their markdown rendering not long ago and your readme's head became incompatible.  This PR fixes that.