### PR TITLE
Fix travis-CI PHP 5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,15 @@ php:
   - 5.6
   - 5.5
   - 5.4
-  - 5.3
   - hhvm
 
 matrix:
   allow_failures:
     - php: hhvm
   fast_finish: true
+  include:
+    - php: 5.3
+      dist: precise
 
 before_script:
   - composer self-update


### PR DESCRIPTION
Travis dropped support for PHP 5.3 on Trusty, but provides a way to run tests
on Precise. This commit updates .travis.yml as documented by Travis.

Travis currently documents this here: https://docs.travis-ci.com/user/reference/trusty#PHP-images