### PR TITLE
Add PHP 7.1 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 7.1
   - 7.0
   - 5.6
   - 5.5


### PR DESCRIPTION
This is a minimal commit which adds PHP 7.1 to .travis.yml