### PR TITLE
Test enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,11 @@
     ],
     "autoload": {
         "psr-4": {
-            "Vectorface\\Whip\\": "./src",
-            "VectorFace\\Whip\\": "./src",
+            "Vectorface\\Whip\\": "./src"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Vectorface\\WhipTests\\": "./tests"
         }
     },
@@ -34,7 +37,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
+        "phpunit/phpunit": "^4.8",
         "squizlabs/php_codesniffer": "~2.0",
         "vectorface/dunit": "~2.0",
         "psr/http-message": "~1.0",

--- a/tests/WhipTest.php
+++ b/tests/WhipTest.php
@@ -24,9 +24,8 @@ THE SOFTWARE.
 */
 namespace Vectorface\WhipTests;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\Whip\Whip;
-use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Test class for testing Whip.
@@ -34,7 +33,7 @@ use Psr\Http\Message\ServerRequestInterface;
  * @copyright Vectorface, Inc 2015
  * @author Daniel Bruce <dbruce@vectorface.com>
  */
-class WhipTest extends PHPUnit_Framework_TestCase
+class WhipTest extends TestCase
 {
     /**
      * Tests that an invalid source format is rejected.


### PR DESCRIPTION
# Changed log
- Using the PHPUnit version `^4.8` to be compatible with latest PHPUnit version.
- Organize the `autoload` and `autoload-dev` namespace in `composer.json`.
- The `Psr\Http\Message\ServerRequestInterface;` namespace is unused because mocking class approach uses the class string, not `::class` magic.