### PR TITLE
Fix read order in forwarded headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.4
   - 7.3
   - 7.2
   - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,18 @@
 language: php
 
 php:
+  - 7.4
   - 7.3
   - 7.2
   - 7.1
   - 7.0
   - 5.6
-  - 5.5
-  - 5.4
   - hhvm-3.30
 
 matrix:
+  fast_finish: true
   allow_failures:
     - php: hhvm-3.30
-  fast_finish: true
-  include:
-    - php: 5.3
-      dist: precise
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -34,13 +34,13 @@
         "source": "https://github.com/Vectorface/whip"
     },
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.6.0",
+        "psr/http-message": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
         "squizlabs/php_codesniffer": "~2.0",
         "vectorface/dunit": "~2.0",
-        "psr/http-message": "~1.0",
         "codeclimate/php-test-reporter": "dev-master"
     }
 }

--- a/src/Whip.php
+++ b/src/Whip.php
@@ -205,8 +205,8 @@ class Whip
     /**
      * Finds the first element in $headers that is present in $_SERVER and
      * returns the IP address mapped to that value.
-     * If the IP address is a list of comma separated values, the last value
-     * in the list will be returned.
+     * If the IP address is a list of comma separated values, the first value
+     * in the list will be returned. According as directive: clientIp, proxy1, proxy2, ...
      * If no IP address is found, we return false.
      * @param array $requestHeaders The request headers to pull data from.
      * @param array $headers The list of headers to check.
@@ -218,7 +218,7 @@ class Whip
         foreach ($headers as $header) {
             if (!empty($requestHeaders[$header])) {
                 $list = explode(',', $requestHeaders[$header]);
-                return trim(end($list));
+                return trim($list[0]);
             }
         }
         return false;

--- a/tests/WhipTest.php
+++ b/tests/WhipTest.php
@@ -96,7 +96,7 @@ class WhipTest extends TestCase
                     )
                 )
             ),
-            $this->getHttpMessageMock("127.0.0.1", array('X-Forwarded-For' => array('192.168.1.1,32.32.32.32')))
+            $this->getHttpMessageMock("127.0.0.1", array('X-Forwarded-For' => array('32.32.32.32,192.168.1.1')))
         );
 
         $this->assertEquals('32.32.32.32', $lookup->getIpAddress());
@@ -160,7 +160,7 @@ class WhipTest extends TestCase
             ),
             array(
                 'REMOTE_ADDR' => $remoteAddr,
-                'HTTP_X_FORWARDED_FOR' => '192.168.1.1,32.32.32.32'
+                'HTTP_X_FORWARDED_FOR' => '32.32.32.32,192.168.1.1'
             )
         );
         $this->assertEquals('32.32.32.32', $lookup->getIpAddress());


### PR DESCRIPTION
According MDN [header directive](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For ). If multiple values exists and splitted by comma. The real client IP is first value, others is proxy addresses. This pull requests fixes incorrect logic with detecting client ip 